### PR TITLE
fix: Allow disable plugins

### DIFF
--- a/docs/multiple-tests/disabled-patterns/patterns.xml
+++ b/docs/multiple-tests/disabled-patterns/patterns.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="\.remarkrc" />
+    </module>
+</module>

--- a/docs/multiple-tests/disabled-patterns/results.xml
+++ b/docs/multiple-tests/disabled-patterns/results.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<checkstyle version="1.5"></checkstyle>

--- a/docs/multiple-tests/disabled-patterns/src/.remarkrc
+++ b/docs/multiple-tests/disabled-patterns/src/.remarkrc
@@ -1,0 +1,5 @@
+{
+  "plugins":  [
+    "remark-validate-links"
+  ]
+}

--- a/docs/multiple-tests/disabled-patterns/src/not-existing-link.md
+++ b/docs/multiple-tests/disabled-patterns/src/not-existing-link.md
@@ -1,0 +1,9 @@
+# Foo
+
+## Bar
+
+# Baz
+
+## Baz
+
+## [Baz](whoops)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,18 @@
 #!/usr/bin/env node
 
 import run from './lib/remark-runner';
+import { isPatternDisabled } from './patterns/disabledPatterns';
 
 /* tslint:disable:no-expression-statement*/
 
 run().then(
   results => {
-    results.forEach(result => {
-      process.stdout.write(`${JSON.stringify(result)}\n`);
-    });
+    results
+      // filter patterns that are in the list of disabled patterns
+      .filter(r => !isPatternDisabled(r.patternId))
+      .forEach(result => {
+        process.stdout.write(`${JSON.stringify(result)}\n`);
+      });
 
     process.exit(0);
   },

--- a/src/patterns/disabledPatterns.ts
+++ b/src/patterns/disabledPatterns.ts
@@ -1,0 +1,8 @@
+const disabledPatterns: ReadonlyArray<string> = ['remark-validate-links'];
+
+export function isPatternDisabled(patternId: string): boolean {
+  return (
+    disabledPatterns.includes(patternId) ||
+    disabledPatterns.find(x => patternId.startsWith(x)) !== undefined
+  );
+}


### PR DESCRIPTION
Some patterns require internet connection to run and this tool is run in an environment without internet access.

This PR allows to disable patterns from returning results which may be false positives due to internet connectivity issues.

Resolves https://github.com/codacy/codacy-meta/issues/253.