### PR TITLE
feature: Support plugins mentioned on remark-lint official documentation

### DIFF
--- a/docs/multiple-tests/external-plugins-config/patterns.xml
+++ b/docs/multiple-tests/external-plugins-config/patterns.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="\.remarkrc" />
+    </module>
+</module>

--- a/docs/multiple-tests/external-plugins-config/results.xml
+++ b/docs/multiple-tests/external-plugins-config/results.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="1.5">
+    <file name="remark-lint-books-links.md">
+        <error source="remark-lint-books-links" line="2" message="[books-links] Missing a space before author" severity="info" />
+    </file>
+    <file name="remark-lint-no-long-code.md">
+        <error source="remark-lint-no-long-code" line="2" message="[no-long-code] Maximum length of each code line is 100, but received 101" severity="info" />
+    </file>
+    <file name="remark-lint-no-repeat-punctuation.md">
+        <error source="remark-lint-no-repeat-punctuation" line="1" message="[no-repeat-punctuation] Should not repeat &quot;!&quot;" severity="info" />
+    </file>
+    <file name="remark-lint-no-url-trailing-slash.md">
+        <error source="remark-lint-no-url-trailing-slash" line="1" message="[no-url-trailing-slash] Remove trailing slash (http://example.com)" severity="info" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/external-plugins-config/src/.remarkrc
+++ b/docs/multiple-tests/external-plugins-config/src/.remarkrc
@@ -1,0 +1,8 @@
+{
+  "plugins":  [
+    "remark-lint-books-links",
+    ["remark-lint-no-long-code", { "length": 100 }],
+    "remark-lint-no-repeat-punctuation",
+    "remark-lint-no-url-trailing-slash"
+  ]
+}

--- a/docs/multiple-tests/external-plugins-config/src/remark-lint-books-links.md
+++ b/docs/multiple-tests/external-plugins-config/src/remark-lint-books-links.md
@@ -1,0 +1,2 @@
+* [Another Awesome Book - John Doe](http://example.com/book.html)
+* [Another Awesome Book](http://example.com/book.html)- John Doe

--- a/docs/multiple-tests/external-plugins-config/src/remark-lint-no-long-code.md
+++ b/docs/multiple-tests/external-plugins-config/src/remark-lint-no-long-code.md
@@ -1,0 +1,3 @@
+```javascript
+console.log("this line contains 101 characters: extra extra extra extra extra extra extra extra ...")
+```

--- a/docs/multiple-tests/external-plugins-config/src/remark-lint-no-repeat-punctuation.md
+++ b/docs/multiple-tests/external-plugins-config/src/remark-lint-no-repeat-punctuation.md
@@ -1,0 +1,1 @@
+Example!!

--- a/docs/multiple-tests/external-plugins-config/src/remark-lint-no-url-trailing-slash.md
+++ b/docs/multiple-tests/external-plugins-config/src/remark-lint-no-url-trailing-slash.md
@@ -1,0 +1,1 @@
+[example.com](http://example.com/)

--- a/package.json
+++ b/package.json
@@ -177,7 +177,11 @@
     "tmp": "^0.2.1",
     "unified": "^9.2.0",
     "unified-engine": "^8.0.0",
-    "vfile": "^4.2.0"
+    "vfile": "^4.2.0",
+    "remark-lint-books-links": "2.1.0",
+    "remark-lint-no-long-code": "0.1.2",
+    "remark-lint-no-repeat-punctuation": "0.1.3",
+    "remark-lint-no-url-trailing-slash": "3.0.1"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.1",

--- a/src/docs/documentation-builder.ts
+++ b/src/docs/documentation-builder.ts
@@ -6,7 +6,11 @@ export default function allRules(): ReadonlyArray<Rule> {
   const remarkLintPath = './node_modules';
   const ignoredRules: ReadonlyArray<string> = [
     'remark-lint-code',
-    'remark-lint-code-eslint'
+    'remark-lint-code-eslint',
+    'remark-lint-no-long-code',
+    'remark-lint-no-repeat-punctuation',
+    'remark-lint-no-url-trailing-slash',
+    'remark-lint-books-links'
   ];
   const parsedRules = fs
     .readdirSync(remarkLintPath)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5999,6 +5999,16 @@ remark-lint-blockquote-indentation@^2.0.0, remark-lint-blockquote-indentation@^2
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
+remark-lint-books-links@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/remark-lint-books-links/-/remark-lint-books-links-2.1.0.tgz#91d150d03bd995c6b6ff67502346742564eb5ab4"
+  integrity sha1-kdFQ0DvZlca2/2dQI0Z0JWTrWrQ=
+  dependencies:
+    mdast-util-to-string "^1.0.2"
+    unified-lint-rule "^1.0.0"
+    unist-util-generated "^1.1.0"
+    unist-util-visit "^1.0.0"
+
 remark-lint-checkbox-character-style@^2.0.0, remark-lint-checkbox-character-style@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/remark-lint-checkbox-character-style/-/remark-lint-checkbox-character-style-2.0.1.tgz#2ff2df31cb0ec99744f5122086610578c2d13754"
@@ -6472,6 +6482,14 @@ remark-lint-no-literal-urls@^2.0.0, remark-lint-no-literal-urls@^2.0.1:
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
 
+remark-lint-no-long-code@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-long-code/-/remark-lint-no-long-code-0.1.2.tgz#7eb14148e0542f9486dedf964738149e8c7f33b4"
+  integrity sha512-wrflkAWhGiPLaZz5eo3NovEvg2kj1yIIFou/cOGD0UTEumZI4TEL0m9Tsu3wq41hBjzXtWlovp4KqH/uw6IIhQ==
+  dependencies:
+    unified-lint-rule "^1.0.3"
+    unist-util-visit "^1.4.0"
+
 remark-lint-no-missing-blank-lines@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/remark-lint-no-missing-blank-lines/-/remark-lint-no-missing-blank-lines-2.0.1.tgz#217bfb35c68eb0486b3db654d6cd3853a1703f8d"
@@ -6510,6 +6528,15 @@ remark-lint-no-reference-like-url@^2.0.1:
     unified-lint-rule "^1.0.0"
     unist-util-generated "^1.1.0"
     unist-util-visit "^2.0.0"
+
+remark-lint-no-repeat-punctuation@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-repeat-punctuation/-/remark-lint-no-repeat-punctuation-0.1.3.tgz#c69c709f91c413cd9a1f005773954d3dbd6d032c"
+  integrity sha512-NoRZimrU7/yiUzjqXD/ZM4+ZAezKXLBCprc6gsM4/m58YKT2m6xqXBY06qIJcLZnmsq1EOOkarVtY0E+h/uI9w==
+  dependencies:
+    unified-lint-rule "^1.0.3"
+    unist-util-map "^1.0.4"
+    unist-util-to-list-of-char "^0.1.2"
 
 remark-lint-no-shell-dollars@^2.0.0, remark-lint-no-shell-dollars@^2.0.2:
   version "2.0.2"
@@ -6594,6 +6621,14 @@ remark-lint-no-unused-definitions@^2.0.0, remark-lint-no-unused-definitions@^2.0
     unified-lint-rule "^1.0.0"
     unist-util-generated "^1.1.0"
     unist-util-visit "^2.0.0"
+
+remark-lint-no-url-trailing-slash@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/remark-lint-no-url-trailing-slash/-/remark-lint-no-url-trailing-slash-3.0.1.tgz#560d3bffce2a9e0c792814999aff090a05792d41"
+  integrity sha512-M1Urq1d6MshfQWo1MpklUhgfxfXpXlbSIdgayvdhLmsaWclVmOqi1i8+0pOyneBdmwbzPNRno7RtsNQjTtCp+A==
+  dependencies:
+    unified-lint-rule "^1.0.0"
+    unist-util-visit "^1.0.0"
 
 remark-lint-ordered-list-marker-style@^2.0.0, remark-lint-ordered-list-marker-style@^2.0.1:
   version "2.0.1"
@@ -8492,6 +8527,13 @@ unified-lint-rule@^1.0.0, unified-lint-rule@^1.0.1, unified-lint-rule@^1.0.2, un
   dependencies:
     wrapped "^1.0.1"
 
+unified-lint-rule@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/unified-lint-rule/-/unified-lint-rule-1.0.6.tgz#b4ab801ff93c251faa917a8d1c10241af030de84"
+  integrity sha512-YPK15YBFwnsVorDFG/u0cVVQN5G2a3V8zv5/N6KN3TCG+ajKtaALcy7u14DCSrJI+gZeyYquFL9cioJXOGXSvg==
+  dependencies:
+    wrapped "^1.0.1"
+
 unified-message-control@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/unified-message-control/-/unified-message-control-3.0.1.tgz#7018855daea9af96082cbea35970d48c9c4dbbf2"
@@ -8595,6 +8637,13 @@ unist-util-is@^4.0.0:
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.2.tgz#c7d1341188aa9ce5b3cff538958de9895f14a5de"
   integrity sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==
 
+unist-util-map@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/unist-util-map/-/unist-util-map-1.0.5.tgz#701069b72e1d1cc02db265502a5e82b77c2eb8b7"
+  integrity sha512-dFil/AN6vqhnQWNCZk0GF/G3+Q5YwsB+PqjnzvpO2wzdRtUJ1E8PN+XRE/PRr/G3FzKjRTJU0haqE0Ekl+O3Ag==
+  dependencies:
+    object-assign "^4.0.1"
+
 unist-util-modify-children@^1.0.0, unist-util-modify-children@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/unist-util-modify-children/-/unist-util-modify-children-1.1.4.tgz#f9dd31e93884c3be06b43c9291d60324d5df5f68"
@@ -8633,6 +8682,13 @@ unist-util-stringify-position@^2.0.0:
   dependencies:
     "@types/unist" "^2.0.2"
 
+unist-util-to-list-of-char@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-to-list-of-char/-/unist-util-to-list-of-char-0.1.2.tgz#0bf702e093028a58078600ebb5e2a4a2cf58f0ae"
+  integrity sha512-5lbFigjFtxEBxx8n9w16UwWjVepQvsamfIlgY3PPDJ+LPR3BmCE7P5ufZM0CE+yizjkuwK8FT8Z0sHfavIc0Cg==
+  dependencies:
+    unist-util-visit "^1.4.0"
+
 unist-util-visit-children@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.3.tgz#92ba5807e3f54637be5de950263f9468942e7503"
@@ -8653,7 +8709,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1, unist-util-visit@^1.3.0:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1, unist-util-visit@^1.3.0, unist-util-visit@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
   integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==


### PR DESCRIPTION
Remark Lint has a list of external rules on the documentation: https://github.com/remarkjs/remark-lint/blob/main/readme.md#list-of-external-rules

Plugins added from that list: 
- [remark-lint-books-links](https://github.com/vhf/remark-lint-books-links)
- [remark-lint-no-long-code](https://github.com/laysent/remark-lint-plugins/tree/HEAD/packages/remark-lint-no-long-code)
- [remark-lint-no-repeat-punctuation](https://github.com/laysent/remark-lint-plugins/tree/HEAD/packages/remark-lint-no-repeat-punctuation)
- [remark-lint-no-url-trailing-slash](https://github.com/vhf/remark-lint-no-url-trailing-slash)
