### PR TITLE
feature: Add enabled by default to pattern with doc auto generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   codacy: codacy/base@2.14.8
-  codacy_plugins_test: codacy/plugins-test@0.10.6
+  codacy_plugins_test: codacy/plugins-test@0.14.5
 
 jobs:
   build_and_test:

--- a/docs/description/remark-lint-checkbox-character-style.md
+++ b/docs/description/remark-lint-checkbox-character-style.md
@@ -13,7 +13,7 @@ Styles can also be passed in like so:
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats checked checkboxes using `x` (lowercase X) and unchecked checkboxes
 as `·` (a single space).
 

--- a/docs/description/remark-lint-code-block-style.md
+++ b/docs/description/remark-lint-code-block-style.md
@@ -7,11 +7,11 @@ subsequent code blocks uses different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats code blocks using a fence if they have a language flag and
 indentation if not.
 Pass
-[`fences: true`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsfences)
+[`fences: true`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsfences)
 to always use fences for code blocks.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-emphasis-marker.md
+++ b/docs/description/remark-lint-emphasis-marker.md
@@ -7,10 +7,10 @@ subsequent emphasis use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats emphasis using `_` (underscore) by default.
 Pass
-[`emphasis: '*'`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsemphasis)
+[`emphasis: '*'`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsemphasis)
 to use `*` (asterisk) instead.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-fenced-code-marker.md
+++ b/docs/description/remark-lint-fenced-code-marker.md
@@ -7,10 +7,10 @@ when subsequent fenced code blocks use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats fences using ``'`'`` (grave accent) by default.
 Pass
-[`fence: '~'`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsfence)
+[`fence: '~'`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsfence)
 to use `~` (tilde) instead.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-final-newline.md
+++ b/docs/description/remark-lint-final-newline.md
@@ -5,7 +5,7 @@ See [StackExchange](https://unix.stackexchange.com/questions/18743) for why.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 always adds a final line feed to files.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-heading-style.md
+++ b/docs/description/remark-lint-heading-style.md
@@ -8,12 +8,12 @@ subsequent headings use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats headings as ATX by default.
 This can be configured with the
-[`setext`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionssetext)
+[`setext`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionssetext)
 and
-[`closeAtx`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionscloseatx)
+[`closeAtx`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionscloseatx)
 options.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-linebreak-style.md
+++ b/docs/description/remark-lint-linebreak-style.md
@@ -6,7 +6,7 @@ a file).  Default: `'consistent'`.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 always uses unix linebreaks.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-link-title-style.md
+++ b/docs/description/remark-lint-link-title-style.md
@@ -7,7 +7,7 @@ titles use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 uses `'` (single quote) for titles if they contain a double quote, and `"`
 (double quotes) otherwise.
 

--- a/docs/description/remark-lint-list-item-bullet-indent.md
+++ b/docs/description/remark-lint-list-item-bullet-indent.md
@@ -2,7 +2,7 @@ Warn when list item bullets are indented.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 removes all indentation before bullets.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-list-item-indent.md
+++ b/docs/description/remark-lint-list-item-indent.md
@@ -5,11 +5,11 @@ Options: `'tab-size'`, `'mixed'`, or `'space'`, default: `'tab-size'`.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 uses `'tab-size'` (named `'tab'` there) by default to ensure Markdown is
 seen the same way across vendors.
 This can be configured with the
-[`listItemIndent`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionslistitemindent)
+[`listItemIndent`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionslistitemindent)
 option.
 This rule’s `'space'` option is named `'1'` there.
 

--- a/docs/description/remark-lint-no-auto-link-without-protocol.md
+++ b/docs/description/remark-lint-no-auto-link-without-protocol.md
@@ -4,7 +4,7 @@ characters.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 adds a protocol where needed.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-no-blockquote-without-marker.md
+++ b/docs/description/remark-lint-no-blockquote-without-marker.md
@@ -3,7 +3,7 @@ block quote.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 adds markers to every line in a block quote.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-no-consecutive-blank-lines.md
+++ b/docs/description/remark-lint-no-consecutive-blank-lines.md
@@ -4,7 +4,7 @@ lists.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 always uses one blank line between blocks if possible, or two lines when
 needed.
 

--- a/docs/description/remark-lint-no-heading-content-indent.md
+++ b/docs/description/remark-lint-no-heading-content-indent.md
@@ -2,7 +2,7 @@ Warn when content of headings is indented.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 removes all unneeded padding around content in headings.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-no-heading-indent.md
+++ b/docs/description/remark-lint-no-heading-indent.md
@@ -2,7 +2,7 @@ Warn when a heading is indented.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 removes all unneeded indentation before headings.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-no-literal-urls.md
+++ b/docs/description/remark-lint-no-literal-urls.md
@@ -5,7 +5,7 @@ To make sure they are always linked, wrap them in `<` (less than) and `>`
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 never creates literal URLs and always uses `<` (less than) and `>`
 (greater than).
 

--- a/docs/description/remark-lint-no-missing-blank-lines.md
+++ b/docs/description/remark-lint-no-missing-blank-lines.md
@@ -7,7 +7,7 @@ between their contents by passing `{exceptTightLists: true}` (default:
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 always uses one blank line between blocks if possible, or two lines when
 needed.
 The style of the list items persists.

--- a/docs/description/remark-lint-no-table-indentation.md
+++ b/docs/description/remark-lint-no-table-indentation.md
@@ -2,7 +2,7 @@ Warn when tables are indented.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 removes all unneeded indentation before tables.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-no-tabs.md
+++ b/docs/description/remark-lint-no-tabs.md
@@ -2,7 +2,7 @@ Warn when hard tabs (`\t`) are used instead of spaces.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 uses spaces where tabs are used for indentation, but retains tabs used in
 content.
 

--- a/docs/description/remark-lint-ordered-list-marker-value.md
+++ b/docs/description/remark-lint-ordered-list-marker-value.md
@@ -11,11 +11,11 @@ When set to `'one'`, bullets should always be `1`.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 retains the number of the first list item bullet, and by default
 increments the other items.
 Pass
-[`incrementListMarker: false`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsincrementlistmarker)
+[`incrementListMarker: false`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsincrementlistmarker)
 to not increment further list items.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-rule-style.md
+++ b/docs/description/remark-lint-rule-style.md
@@ -9,14 +9,14 @@ subsequent rules use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 has three settings that define how rules are created:
 
-*   [`rule`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsrule)
+*   [`rule`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsrule)
     (default: `*`) — Marker to use
-*   [`ruleRepetition`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsrulerepetition)
+*   [`ruleRepetition`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsrulerepetition)
     (default: `3`) — Number of markers to use
-*   [`ruleSpaces`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsrulespaces)
+*   [`ruleSpaces`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsrulespaces)
     (default: `true`) — Whether to pad markers with spaces
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-strong-marker.md
+++ b/docs/description/remark-lint-strong-marker.md
@@ -7,10 +7,10 @@ subsequent importance sequences use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats importance using an `*` (asterisk) by default.
 Pass
-[`strong: '_'`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsstrong)
+[`strong: '_'`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsstrong)
 to use `_` (underscore) instead.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-table-cell-padding.md
+++ b/docs/description/remark-lint-table-cell-padding.md
@@ -7,10 +7,10 @@ subsequent cells use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats tables with padding by default.
 Pass
-[`spacedTable: false`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsspacedtable)
+[`spacedTable: false`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsspacedtable)
 to not use padding.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-table-pipe-alignment.md
+++ b/docs/description/remark-lint-table-pipe-alignment.md
@@ -2,17 +2,17 @@ Warn when table pipes are not aligned.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 tries to align tables by default.
 Pass
-[`paddedTable: false`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionspaddedtable)
+[`paddedTable: false`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionspaddedtable)
 to not align cells.
 
 Aligning cells perfectly is impossible as some characters (such as emoji or
 Chinese characters) are rendered differently in different browsers,
 terminals, and editors.
 You can pass your own
-[`stringLength`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsstringlength)
+[`stringLength`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsstringlength)
 function to customize how cells are aligned.
 In that case, this rule must be turned off.
 

--- a/docs/description/remark-lint-table-pipes.md
+++ b/docs/description/remark-lint-table-pipes.md
@@ -2,10 +2,10 @@ Warn when table rows are not fenced with pipes.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 creates fenced rows with initial and final pipes by default.
 Pass
-[`looseTable: true`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsloosetable)
+[`looseTable: true`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsloosetable)
 to not use row fences.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/description/remark-lint-unordered-list-marker-style.md
+++ b/docs/description/remark-lint-unordered-list-marker-style.md
@@ -1,17 +1,17 @@
 Warn when the list item marker style of unordered lists violate a given
 style.
 
-Options: `'consistent'`, `'-'`, `'*'`, or `'*'`, default: `'consistent'`.
+Options: `'consistent'`, `'-'`, `'*'`, or `'+'`, default: `'consistent'`.
 
 `'consistent'` detects the first used list style and warns when subsequent
 lists use different styles.
 
 ## Fix
 
-[`remark-stringify`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify)
+[`remark-stringify`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify)
 formats unordered lists using `-` (hyphen-minus) by default.
 Pass
-[`bullet: '*'` or `bullet: '+'`](https://github.com/remarkjs/remark/tree/master/packages/remark-stringify#optionsbullet)
+[`bullet: '*'` or `bullet: '+'`](https://github.com/remarkjs/remark/tree/HEAD/packages/remark-stringify#optionsbullet)
 to use `*` (asterisk) or `+` (plus sign) instead.
 
 See [Using remark to fix your Markdown](https://github.com/remarkjs/remark-lint#using-remark-to-fix-your-markdown)

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -4,12 +4,14 @@
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-alphabetize-lists"
+      "patternId": "remark-lint-alphabetize-lists",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-blank-lines-1-0-2"
+      "patternId": "remark-lint-blank-lines-1-0-2",
+      "enabled": false
     },
     {
       "parameters": [
@@ -20,7 +22,8 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-blockquote-indentation"
+      "patternId": "remark-lint-blockquote-indentation",
+      "enabled": true
     },
     {
       "parameters": [
@@ -31,12 +34,14 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-checkbox-character-style"
+      "patternId": "remark-lint-checkbox-character-style",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-checkbox-content-indent"
+      "patternId": "remark-lint-checkbox-content-indent",
+      "enabled": false
     },
     {
       "parameters": [
@@ -47,17 +52,20 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-code-block-style"
+      "patternId": "remark-lint-code-block-style",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-definition-case"
+      "patternId": "remark-lint-definition-case",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-definition-spacing"
+      "patternId": "remark-lint-definition-spacing",
+      "enabled": false
     },
     {
       "parameters": [
@@ -68,12 +76,14 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-emphasis-marker"
+      "patternId": "remark-lint-emphasis-marker",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-fenced-code-flag"
+      "patternId": "remark-lint-fenced-code-flag",
+      "enabled": false
     },
     {
       "parameters": [
@@ -84,7 +94,8 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-fenced-code-marker"
+      "patternId": "remark-lint-fenced-code-marker",
+      "enabled": true
     },
     {
       "parameters": [
@@ -95,17 +106,20 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-file-extension"
+      "patternId": "remark-lint-file-extension",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-final-definition"
+      "patternId": "remark-lint-final-definition",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-final-newline"
+      "patternId": "remark-lint-final-newline",
+      "enabled": true
     },
     {
       "parameters": [
@@ -116,32 +130,38 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-first-heading-level"
+      "patternId": "remark-lint-first-heading-level",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-hard-break-spaces"
+      "patternId": "remark-lint-hard-break-spaces",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-heading-increment"
+      "patternId": "remark-lint-heading-increment",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-heading-style"
+      "patternId": "remark-lint-heading-style",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-heading-whitespace"
+      "patternId": "remark-lint-heading-whitespace",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-linebreak-style"
+      "patternId": "remark-lint-linebreak-style",
+      "enabled": false
     },
     {
       "parameters": [
@@ -152,17 +172,20 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-link-title-style"
+      "patternId": "remark-lint-link-title-style",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-list-item-bullet-indent"
+      "patternId": "remark-lint-list-item-bullet-indent",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-list-item-content-indent"
+      "patternId": "remark-lint-list-item-content-indent",
+      "enabled": true
     },
     {
       "parameters": [
@@ -173,12 +196,14 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-list-item-indent"
+      "patternId": "remark-lint-list-item-indent",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-list-item-spacing"
+      "patternId": "remark-lint-list-item-spacing",
+      "enabled": false
     },
     {
       "parameters": [
@@ -189,7 +214,8 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-maximum-heading-length"
+      "patternId": "remark-lint-maximum-heading-length",
+      "enabled": false
     },
     {
       "parameters": [
@@ -200,72 +226,86 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-maximum-line-length"
+      "patternId": "remark-lint-maximum-line-length",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-auto-link-without-protocol"
+      "patternId": "remark-lint-no-auto-link-without-protocol",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-blockquote-without-marker"
+      "patternId": "remark-lint-no-blockquote-without-marker",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-consecutive-blank-lines"
+      "patternId": "remark-lint-no-consecutive-blank-lines",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-dead-urls"
+      "patternId": "remark-lint-no-dead-urls",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-duplicate-defined-urls"
+      "patternId": "remark-lint-no-duplicate-defined-urls",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-duplicate-definitions"
+      "patternId": "remark-lint-no-duplicate-definitions",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-duplicate-headings"
+      "patternId": "remark-lint-no-duplicate-headings",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-duplicate-headings-in-section"
+      "patternId": "remark-lint-no-duplicate-headings-in-section",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-emphasis-as-heading"
+      "patternId": "remark-lint-no-emphasis-as-heading",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-empty-sections"
+      "patternId": "remark-lint-no-empty-sections",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-empty-url"
+      "patternId": "remark-lint-no-empty-url",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-file-name-articles"
+      "patternId": "remark-lint-no-file-name-articles",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-file-name-consecutive-dashes"
+      "patternId": "remark-lint-no-file-name-consecutive-dashes",
+      "enabled": false
     },
     {
       "parameters": [
@@ -276,32 +316,38 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-file-name-irregular-characters"
+      "patternId": "remark-lint-no-file-name-irregular-characters",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-file-name-mixed-case"
+      "patternId": "remark-lint-no-file-name-mixed-case",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-file-name-outer-dashes"
+      "patternId": "remark-lint-no-file-name-outer-dashes",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-heading-content-indent"
+      "patternId": "remark-lint-no-heading-content-indent",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-heading-indent"
+      "patternId": "remark-lint-no-heading-indent",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-heading-like-paragraph"
+      "patternId": "remark-lint-no-heading-like-paragraph",
+      "enabled": false
     },
     {
       "parameters": [
@@ -312,27 +358,32 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-heading-punctuation"
+      "patternId": "remark-lint-no-heading-punctuation",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-html"
+      "patternId": "remark-lint-no-html",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-inline-padding"
+      "patternId": "remark-lint-no-inline-padding",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-literal-urls"
+      "patternId": "remark-lint-no-literal-urls",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-missing-blank-lines"
+      "patternId": "remark-lint-no-missing-blank-lines",
+      "enabled": false
     },
     {
       "parameters": [
@@ -343,62 +394,74 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-multiple-toplevel-headings"
+      "patternId": "remark-lint-no-multiple-toplevel-headings",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-paragraph-content-indent"
+      "patternId": "remark-lint-no-paragraph-content-indent",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-reference-like-url"
+      "patternId": "remark-lint-no-reference-like-url",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-shell-dollars"
+      "patternId": "remark-lint-no-shell-dollars",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-shortcut-reference-image"
+      "patternId": "remark-lint-no-shortcut-reference-image",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-shortcut-reference-link"
+      "patternId": "remark-lint-no-shortcut-reference-link",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-table-indentation"
+      "patternId": "remark-lint-no-table-indentation",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-tabs"
+      "patternId": "remark-lint-no-tabs",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-undefined-references"
+      "patternId": "remark-lint-no-undefined-references",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-unneeded-full-reference-image"
+      "patternId": "remark-lint-no-unneeded-full-reference-image",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-unneeded-full-reference-link"
+      "patternId": "remark-lint-no-unneeded-full-reference-link",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-no-unused-definitions"
+      "patternId": "remark-lint-no-unused-definitions",
+      "enabled": true
     },
     {
       "parameters": [
@@ -409,7 +472,8 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-ordered-list-marker-style"
+      "patternId": "remark-lint-ordered-list-marker-style",
+      "enabled": true
     },
     {
       "parameters": [
@@ -420,12 +484,14 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-ordered-list-marker-value"
+      "patternId": "remark-lint-ordered-list-marker-value",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-rule-style"
+      "patternId": "remark-lint-rule-style",
+      "enabled": true
     },
     {
       "parameters": [
@@ -436,7 +502,8 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-strong-marker"
+      "patternId": "remark-lint-strong-marker",
+      "enabled": true
     },
     {
       "parameters": [
@@ -447,17 +514,20 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-table-cell-padding"
+      "patternId": "remark-lint-table-cell-padding",
+      "enabled": true
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-table-pipe-alignment"
+      "patternId": "remark-lint-table-pipe-alignment",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-table-pipes"
+      "patternId": "remark-lint-table-pipes",
+      "enabled": false
     },
     {
       "parameters": [
@@ -468,13 +538,15 @@
       ],
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-unordered-list-marker-style"
+      "patternId": "remark-lint-unordered-list-marker-style",
+      "enabled": false
     },
     {
       "category": "CodeStyle",
       "level": "Warning",
-      "patternId": "remark-lint-write-good"
+      "patternId": "remark-lint-write-good",
+      "enabled": false
     }
   ],
-  "version": "7.0.0"
+  "version": "7.0.1"
 }

--- a/src/codacy-docs.ts
+++ b/src/codacy-docs.ts
@@ -2,10 +2,14 @@
 
 import fs from 'fs-extra';
 import path from 'path';
-import getAllRules from './docs/documentation-builder';
+import {
+  getAllRules,
+  remarkPresetLintRecommended
+} from './docs/documentation-builder';
 import { Rule } from './docs/util/rule';
 
 /* tslint:disable:no-expression-statement*/
+const defaults = remarkPresetLintRecommended();
 
 const root = path.resolve(__dirname);
 const docsPath = path.resolve(`${root}/../../docs`);
@@ -21,7 +25,7 @@ fs.mkdirSync(descripionPath);
 
 fs.writeFileSync(
   `${docsPath}/patterns.json`,
-  JSON.stringify(getPatterns(allRules), null, 2)
+  JSON.stringify(getPatterns(allRules, defaults), null, 2)
 );
 
 fs.writeFileSync(
@@ -44,7 +48,10 @@ fs.writeFileSync(
 
 /* tslint:enable:no-expression-statement*/
 
-function getPatterns(rules: ReadonlyArray<Rule>): object {
+function getPatterns(
+  rules: ReadonlyArray<Rule>,
+  enabledByDefaultPatterns: ReadonlyArray<string>
+): object {
   const patterns = rules.map((rule: Rule) => {
     const parameters = rule.defaultValue
       ? {
@@ -60,6 +67,7 @@ function getPatterns(rules: ReadonlyArray<Rule>): object {
     return {
       ...parameters,
       category: 'CodeStyle',
+      enabled: enabledByDefaultPatterns.includes(rule.ruleId),
       level: 'Warning',
       patternId: rule.ruleId
     };

--- a/src/docs/documentation-builder.ts
+++ b/src/docs/documentation-builder.ts
@@ -2,16 +2,23 @@ import fs from 'fs-extra';
 import path from 'path';
 import rule, { Rule } from './util/rule';
 
-export default function allRules(): ReadonlyArray<Rule> {
-  const remarkLintPath = './node_modules';
-  const ignoredRules: ReadonlyArray<string> = [
-    'remark-lint-code',
-    'remark-lint-code-eslint',
-    'remark-lint-no-long-code',
-    'remark-lint-no-repeat-punctuation',
-    'remark-lint-no-url-trailing-slash',
-    'remark-lint-books-links'
-  ];
+const remarkLintPath = './node_modules';
+
+const defaultPresetRules: ReadonlyArray<string> = [
+  'remark-preset-lint-consistent',
+  'remark-preset-lint-recommended'
+];
+
+const ignoredRules: ReadonlyArray<string> = [
+  'remark-lint-code',
+  'remark-lint-code-eslint',
+  'remark-lint-no-long-code',
+  'remark-lint-no-repeat-punctuation',
+  'remark-lint-no-url-trailing-slash',
+  'remark-lint-books-links'
+];
+
+export function getAllRules(): ReadonlyArray<Rule> {
   const parsedRules = fs
     .readdirSync(remarkLintPath)
     .filter((name) => /remark-lint-.*/.test(name))
@@ -24,4 +31,42 @@ export default function allRules(): ReadonlyArray<Rule> {
     ) as ReadonlyArray<Rule>;
 
   return parsedRules;
+}
+
+export function remarkPresetLintRecommended(): ReadonlyArray<string> {
+  const presetPatternRequireNameRegex = /require\(\'(.+)\'\)/;
+
+  const defaultsList = defaultPresetRules.reduce(
+    (listOfDefaultPatterns: ReadonlyArray<string>, preset: string) => {
+      const presetDefinitionFileLocation = path.join(
+        remarkLintPath,
+        preset,
+        'index.js'
+      );
+      const presetDefinitionFileContent = fs
+        .readFileSync(presetDefinitionFileLocation)
+        .toString();
+
+      const presetPatternIds = presetDefinitionFileContent
+        .split('\n')
+        .map((line: string) => {
+          const patternName = line.match(presetPatternRequireNameRegex);
+          if (patternName) {
+            return patternName[1];
+          }
+          return undefined;
+        })
+        .filter(
+          (ruleId) =>
+            ruleId !== undefined &&
+            ruleId !== 'remark-lint' &&
+            !ignoredRules.includes(ruleId)
+        ) as ReadonlyArray<string>;
+
+      return listOfDefaultPatterns.concat(...presetPatternIds);
+    },
+    []
+  );
+
+  return defaultsList;
 }

--- a/src/lib/codacy-configuration.ts
+++ b/src/lib/codacy-configuration.ts
@@ -20,7 +20,7 @@ interface CodacyParameter {
 
 interface CodacyPattern {
   readonly patternId: string;
-  readonly parameters?: ReadonlyArray<CodacyParameter>;
+  readonly parameters: ReadonlyArray<CodacyParameter>;
 }
 
 interface CodacyTool {
@@ -68,7 +68,6 @@ function parseCodacyConfiguration(
     // tslint:disable-next-line:no-expression-statement
     process.stderr.write(`${err}\n`);
     process.exit(50);
-    return;
   }
 }
 


### PR DESCRIPTION
Used these presets to get the defaults:

- remark-preset-lint-recommended — rules that prevent mistakes or syntaxes that do not work correctly across vendors
- remark-preset-lint-consistent — rules that enforce consistency

These presets are mentioned here:
https://github.com/remarkjs/remark-lint#list-of-presets

These are also suggested in this internal issue: https://codacy.atlassian.net/browse/DOCS-110