### PR TITLE
security: Delay dependabot updates [TAROT-3707]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,39 +1,41 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Lisbon
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: "@types/node"
-    versions:
-    - 14.14.22
-    - 14.14.24
-    - 14.14.25
-    - 14.14.26
-    - 14.14.28
-    - 14.14.30
-    - 15.0.0
-  - dependency-name: fs-extra
-    versions:
-    - 9.1.0
-  - dependency-name: typedoc
-    versions:
-    - 0.20.19
-    - 0.20.20
-    - 0.20.23
-    - 0.20.24
-    - 0.20.25
-    - 0.20.27
-    - 0.20.28
-  - dependency-name: "@types/fs-extra"
-    versions:
-    - 9.0.7
-  - dependency-name: typescript
-    versions:
-    - 3.9.8
-  - dependency-name: retext-indefinite-article
-    versions:
-    - 2.0.2
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Lisbon
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
+        versions:
+          - 14.14.22
+          - 14.14.24
+          - 14.14.25
+          - 14.14.26
+          - 14.14.28
+          - 14.14.30
+          - 15.0.0
+      - dependency-name: fs-extra
+        versions:
+          - 9.1.0
+      - dependency-name: typedoc
+        versions:
+          - 0.20.19
+          - 0.20.20
+          - 0.20.23
+          - 0.20.24
+          - 0.20.25
+          - 0.20.27
+          - 0.20.28
+      - dependency-name: "@types/fs-extra"
+        versions:
+          - 9.0.7
+      - dependency-name: typescript
+        versions:
+          - 3.9.8
+      - dependency-name: retext-indefinite-article
+        versions:
+          - 2.0.2
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
7 days should be enough when most malicious packages are patched within 24 hours.